### PR TITLE
chore: make all crates publishable to crates.io

### DIFF
--- a/crates/rayo-core/Cargo.toml
+++ b/crates/rayo-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "rayo-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core AI-native browser automation layer for rayo-browser"
 
 [dependencies]
@@ -15,7 +16,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
-rayo-profiler = { path = "../rayo-profiler" }
+rayo-profiler = { version = "0.1.0", path = "../rayo-profiler" }
 base64 = "0.22"
 tempfile = "3"
 

--- a/crates/rayo-mcp/Cargo.toml
+++ b/crates/rayo-mcp/Cargo.toml
@@ -3,6 +3,7 @@ name = "rayo-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "The fastest MCP browser automation server"
 
 [lib]
@@ -14,9 +15,9 @@ name = "rayo-mcp"
 path = "src/main.rs"
 
 [dependencies]
-rayo-core = { path = "../rayo-core" }
-rayo-profiler = { path = "../rayo-profiler" }
-rayo-rules = { path = "../rayo-rules" }
+rayo-core = { version = "0.1.0", path = "../rayo-core" }
+rayo-profiler = { version = "0.1.0", path = "../rayo-profiler" }
+rayo-rules = { version = "0.1.0", path = "../rayo-rules" }
 chromiumoxide = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/rayo-profiler/Cargo.toml
+++ b/crates/rayo-profiler/Cargo.toml
@@ -3,6 +3,7 @@ name = "rayo-profiler"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Built-in profiling for rayo-browser — zero overhead when disabled"
 
 [dependencies]

--- a/crates/rayo-rules/Cargo.toml
+++ b/crates/rayo-rules/Cargo.toml
@@ -3,10 +3,11 @@ name = "rayo-rules"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "AI agent speed rules engine for rayo-browser"
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rayo-profiler = { path = "../rayo-profiler" }
+rayo-profiler = { version = "0.1.0", path = "../rayo-profiler" }


### PR DESCRIPTION
## Summary
- Add `version = "0.1.0"` alongside `path` in all inter-crate dependencies so `cargo publish` works
- Add `repository.workspace = true` to all crate manifests (required by crates.io)

Once merged, publish in order:
```bash
cargo publish -p rayo-profiler
cargo publish -p rayo-rules
cargo publish -p rayo-core
cargo publish -p rayo-mcp
```

Then `cargo install rayo-mcp` works as documented in the README.

## Test plan
- [x] `cargo check` passes
- [x] `cargo publish --dry-run --allow-dirty -p rayo-profiler` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)