### PR TITLE
Add cookie import from real browsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,29 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +649,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -689,6 +723,18 @@ dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -889,6 +935,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -903,6 +958,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -921,6 +985,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1172,6 +1245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1331,17 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1409,6 +1502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1539,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1576,15 +1685,20 @@ dependencies = [
 name = "rayo-core"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "anyhow",
  "axum",
  "base64 0.22.1",
  "chromiumoxide",
  "futures",
+ "hmac",
  "lru",
+ "pbkdf2",
  "rayo-profiler",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1752,6 +1866,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1977,6 +2105,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2344,6 +2478,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/rayo-core/Cargo.toml
+++ b/crates/rayo-core/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 repository.workspace = true
 description = "Core AI-native browser automation layer for rayo-browser"
 
+[features]
+default = []
+cookie-import = ["dep:rusqlite", "dep:aes", "dep:pbkdf2", "dep:sha1", "dep:hmac"]
+
 [dependencies]
 chromiumoxide = { workspace = true }
 tokio = { workspace = true }
@@ -19,6 +23,13 @@ futures = { workspace = true }
 rayo-profiler = { version = "0.1.0", path = "../rayo-profiler" }
 base64 = "0.22"
 tempfile = "3"
+
+# cookie-import feature deps
+rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+aes = { version = "0.8", optional = true }
+pbkdf2 = { version = "0.12", optional = true }
+sha1 = { version = "0.10", optional = true }
+hmac = { version = "0.12", optional = true }
 
 [dev-dependencies]
 which = "6"

--- a/crates/rayo-core/src/cookie_import.rs
+++ b/crates/rayo-core/src/cookie_import.rs
@@ -1,0 +1,496 @@
+//! Import cookies from real browser profiles.
+//!
+//! Reads Chromium-based browser cookie databases (SQLite), decrypts values
+//! using the OS keychain (macOS) or default password (Linux), and converts
+//! them to [`SetCookie`] for injection into the headless browser.
+//!
+//! Supported browsers: Chrome, Arc, Brave, Edge, Chromium.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use crate::cookie::{SameSite, SetCookie};
+use crate::error::RayoError;
+
+/// Supported browser types for cookie import.
+#[derive(Debug, Clone, Copy)]
+pub enum BrowserType {
+    Chrome,
+    Arc,
+    Brave,
+    Edge,
+    Chromium,
+}
+
+impl fmt::Display for BrowserType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Chrome => write!(f, "Chrome"),
+            Self::Arc => write!(f, "Arc"),
+            Self::Brave => write!(f, "Brave"),
+            Self::Edge => write!(f, "Edge"),
+            Self::Chromium => write!(f, "Chromium"),
+        }
+    }
+}
+
+impl BrowserType {
+    /// Parse from a string (case-insensitive).
+    pub fn from_name(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "chrome" => Some(Self::Chrome),
+            "arc" => Some(Self::Arc),
+            "brave" => Some(Self::Brave),
+            "edge" => Some(Self::Edge),
+            "chromium" => Some(Self::Chromium),
+            _ => None,
+        }
+    }
+
+    /// macOS Keychain service name for the browser's cookie encryption key.
+    #[cfg(target_os = "macos")]
+    fn keychain_service(&self) -> &'static str {
+        match self {
+            Self::Chrome => "Chrome Safe Storage",
+            Self::Arc => "Arc Safe Storage",
+            Self::Brave => "Brave Safe Storage",
+            Self::Edge => "Microsoft Edge Safe Storage",
+            Self::Chromium => "Chromium Safe Storage",
+        }
+    }
+
+    /// Base directory for browser profiles.
+    fn profile_base_dir(&self) -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_default();
+
+        #[cfg(target_os = "macos")]
+        {
+            let app_support = format!("{home}/Library/Application Support");
+            match self {
+                Self::Chrome => PathBuf::from(format!("{app_support}/Google/Chrome")),
+                Self::Arc => PathBuf::from(format!("{app_support}/Arc/User Data")),
+                Self::Brave => PathBuf::from(format!("{app_support}/BraveSoftware/Brave-Browser")),
+                Self::Edge => PathBuf::from(format!("{app_support}/Microsoft Edge")),
+                Self::Chromium => PathBuf::from(format!("{app_support}/Chromium")),
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let config = format!("{home}/.config");
+            match self {
+                Self::Chrome => PathBuf::from(format!("{config}/google-chrome")),
+                Self::Arc => PathBuf::from(format!("{config}/arc")),
+                Self::Brave => PathBuf::from(format!("{config}/BraveSoftware/Brave-Browser")),
+                Self::Edge => PathBuf::from(format!("{config}/microsoft-edge")),
+                Self::Chromium => PathBuf::from(format!("{config}/chromium")),
+            }
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            let _ = home;
+            PathBuf::new()
+        }
+    }
+
+    /// Cookie database path for a given profile.
+    fn cookie_db_path(&self, profile: &str) -> PathBuf {
+        self.profile_base_dir().join(profile).join("Cookies")
+    }
+
+    /// List available profiles that have cookie databases.
+    pub fn list_profiles(&self) -> Vec<String> {
+        let base = self.profile_base_dir();
+        let mut profiles = Vec::new();
+
+        if base.join("Default").join("Cookies").exists() {
+            profiles.push("Default".to_string());
+        }
+
+        if let Ok(entries) = std::fs::read_dir(&base) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with("Profile ") && entry.path().join("Cookies").exists() {
+                    profiles.push(name);
+                }
+            }
+        }
+
+        profiles
+    }
+}
+
+/// All browser types for enumeration.
+const ALL_BROWSERS: [BrowserType; 5] = [
+    BrowserType::Chrome,
+    BrowserType::Arc,
+    BrowserType::Brave,
+    BrowserType::Edge,
+    BrowserType::Chromium,
+];
+
+/// List browsers that have cookie databases on this machine.
+pub fn list_available_browsers() -> Vec<(BrowserType, Vec<String>)> {
+    ALL_BROWSERS
+        .into_iter()
+        .filter_map(|b| {
+            let profiles = b.list_profiles();
+            if profiles.is_empty() {
+                None
+            } else {
+                Some((b, profiles))
+            }
+        })
+        .collect()
+}
+
+/// Import cookies from a real browser's cookie database.
+///
+/// Reads the Chromium SQLite cookie store, decrypts encrypted values,
+/// and returns `SetCookie` objects ready to inject into the headless browser.
+pub fn import_cookies(
+    browser: BrowserType,
+    domain: Option<&str>,
+    profile: Option<&str>,
+) -> Result<Vec<SetCookie>, RayoError> {
+    let profile = profile.unwrap_or("Default");
+    let db_path = browser.cookie_db_path(profile);
+
+    if !db_path.exists() {
+        return Err(RayoError::CookieError(format!(
+            "Cookie database not found: {}. Is {} installed? Available profiles: {:?}",
+            db_path.display(),
+            browser,
+            browser.list_profiles(),
+        )));
+    }
+
+    let key = derive_decryption_key(browser)?;
+    read_cookies_from_db(&db_path, domain, &key)
+}
+
+/// Derive the AES-128 key used to decrypt Chrome cookie values.
+///
+/// Uses PBKDF2-HMAC-SHA1 with the browser's encryption password,
+/// salt "saltysalt", 1003 iterations, producing a 16-byte key.
+fn derive_decryption_key(browser: BrowserType) -> Result<[u8; 16], RayoError> {
+    let password = get_encryption_password(browser)?;
+
+    let mut key = [0u8; 16];
+    pbkdf2::pbkdf2::<hmac::Hmac<sha1::Sha1>>(password.as_bytes(), b"saltysalt", 1003, &mut key)
+        .map_err(|e| RayoError::CookieError(format!("PBKDF2 key derivation failed: {e}")))?;
+
+    Ok(key)
+}
+
+/// Get the encryption password from the macOS Keychain.
+#[cfg(target_os = "macos")]
+fn get_encryption_password(browser: BrowserType) -> Result<String, RayoError> {
+    let service = browser.keychain_service();
+    let output = std::process::Command::new("security")
+        .args(["find-generic-password", "-s", service, "-w"])
+        .output()
+        .map_err(|e| RayoError::CookieError(format!("Failed to run `security` command: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(RayoError::CookieError(format!(
+            "Failed to get encryption key from Keychain for '{}': {}. \
+             You may need to allow access in the Keychain prompt.",
+            service,
+            stderr.trim()
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// On Linux, Chromium uses "peanuts" as the default encryption password.
+#[cfg(target_os = "linux")]
+fn get_encryption_password(_browser: BrowserType) -> Result<String, RayoError> {
+    Ok("peanuts".to_string())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn get_encryption_password(_browser: BrowserType) -> Result<String, RayoError> {
+    Err(RayoError::CookieError(
+        "Cookie import is only supported on macOS and Linux".to_string(),
+    ))
+}
+
+/// Raw cookie row from the Chromium SQLite database.
+struct RawCookie {
+    host_key: String,
+    name: String,
+    value: String,
+    encrypted_value: Vec<u8>,
+    path: String,
+    is_secure: bool,
+    is_httponly: bool,
+    expires_utc: i64,
+    samesite: i32,
+}
+
+/// Read and decrypt cookies from the Chromium SQLite cookie database.
+fn read_cookies_from_db(
+    db_path: &std::path::Path,
+    domain: Option<&str>,
+    key: &[u8; 16],
+) -> Result<Vec<SetCookie>, RayoError> {
+    // Copy database files to a temp dir to avoid lock contention with the running browser.
+    // Chrome uses WAL mode, so we copy the -wal and -shm files too.
+    let temp_dir = tempfile::tempdir()
+        .map_err(|e| RayoError::CookieError(format!("Failed to create temp dir: {e}")))?;
+    let temp_db = temp_dir.path().join("Cookies");
+
+    std::fs::copy(db_path, &temp_db).map_err(|e| {
+        RayoError::CookieError(format!(
+            "Failed to copy cookie database: {e}. Is the browser running with a lock?"
+        ))
+    })?;
+
+    // Copy WAL/SHM files if present (Chrome names them Cookies-wal, Cookies-shm)
+    if let Some(parent) = db_path.parent() {
+        for suffix in ["Cookies-wal", "Cookies-shm"] {
+            let src = parent.join(suffix);
+            if src.exists() {
+                let _ = std::fs::copy(&src, temp_dir.path().join(suffix));
+            }
+        }
+    }
+
+    let conn = rusqlite::Connection::open_with_flags(
+        &temp_db,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| RayoError::CookieError(format!("Failed to open cookie database: {e}")))?;
+
+    let base_query = "SELECT host_key, name, value, encrypted_value, path, \
+                      is_secure, is_httponly, expires_utc, samesite FROM cookies";
+
+    let mut cookies = Vec::new();
+
+    if let Some(domain) = domain {
+        let query = format!("{base_query} WHERE host_key LIKE ?1");
+        let pattern = format!("%{domain}%");
+        let mut stmt = conn
+            .prepare(&query)
+            .map_err(|e| RayoError::CookieError(format!("SQL prepare failed: {e}")))?;
+        let rows = stmt
+            .query_map([&pattern], map_cookie_row)
+            .map_err(|e| RayoError::CookieError(format!("SQL query failed: {e}")))?;
+        for row in rows {
+            if let Some(cookie) = process_row(row, key)? {
+                cookies.push(cookie);
+            }
+        }
+    } else {
+        let mut stmt = conn
+            .prepare(base_query)
+            .map_err(|e| RayoError::CookieError(format!("SQL prepare failed: {e}")))?;
+        let rows = stmt
+            .query_map([], map_cookie_row)
+            .map_err(|e| RayoError::CookieError(format!("SQL query failed: {e}")))?;
+        for row in rows {
+            if let Some(cookie) = process_row(row, key)? {
+                cookies.push(cookie);
+            }
+        }
+    }
+
+    Ok(cookies)
+}
+
+fn map_cookie_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawCookie> {
+    Ok(RawCookie {
+        host_key: row.get(0)?,
+        name: row.get(1)?,
+        value: row.get(2)?,
+        encrypted_value: row.get(3)?,
+        path: row.get(4)?,
+        is_secure: row.get::<_, i32>(5)? != 0,
+        is_httponly: row.get::<_, i32>(6)? != 0,
+        expires_utc: row.get(7)?,
+        samesite: row.get(8)?,
+    })
+}
+
+/// Process a raw cookie row: decrypt value and convert to SetCookie.
+fn process_row(
+    row: rusqlite::Result<RawCookie>,
+    key: &[u8; 16],
+) -> Result<Option<SetCookie>, RayoError> {
+    let raw = row.map_err(|e| RayoError::CookieError(format!("Failed to read cookie row: {e}")))?;
+
+    // Prefer encrypted_value; fall back to plaintext value column
+    let value = if !raw.encrypted_value.is_empty() {
+        decrypt_cookie_value(&raw.encrypted_value, key).unwrap_or(raw.value)
+    } else {
+        raw.value
+    };
+
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    // Chrome epoch: microseconds since 1601-01-01
+    // Unix epoch: seconds since 1970-01-01
+    // Delta: 11,644,473,600 seconds
+    let expires = if raw.expires_utc > 0 {
+        Some((raw.expires_utc as f64 / 1_000_000.0) - 11_644_473_600.0)
+    } else {
+        None
+    };
+
+    let same_site = match raw.samesite {
+        2 => Some(SameSite::Strict),
+        1 => Some(SameSite::Lax),
+        0 => Some(SameSite::None),
+        _ => None,
+    };
+
+    Ok(Some(SetCookie {
+        name: raw.name,
+        value,
+        domain: Some(raw.host_key),
+        path: Some(raw.path),
+        url: None,
+        secure: Some(raw.is_secure),
+        http_only: Some(raw.is_httponly),
+        same_site,
+        expires,
+    }))
+}
+
+/// Decrypt a Chromium-encrypted cookie value.
+///
+/// Chromium encrypts cookie values with a "v10" prefix followed by
+/// AES-128-CBC ciphertext (IV = 0x00*16) with PKCS7 padding.
+fn decrypt_cookie_value(encrypted: &[u8], key: &[u8; 16]) -> Result<String, RayoError> {
+    if encrypted.len() < 3 {
+        return String::from_utf8(encrypted.to_vec())
+            .map_err(|e| RayoError::CookieError(format!("Cookie value is not valid UTF-8: {e}")));
+    }
+
+    match &encrypted[..3] {
+        b"v10" => {
+            let ciphertext = &encrypted[3..];
+            if ciphertext.is_empty() || !ciphertext.len().is_multiple_of(16) {
+                return Err(RayoError::CookieError(format!(
+                    "Invalid ciphertext length: {}",
+                    ciphertext.len()
+                )));
+            }
+            let plaintext = decrypt_aes_128_cbc(ciphertext, key);
+            String::from_utf8(plaintext).map_err(|e| {
+                RayoError::CookieError(format!("Decrypted cookie is not valid UTF-8: {e}"))
+            })
+        }
+        _ => {
+            // Unknown prefix — try as raw UTF-8
+            String::from_utf8(encrypted.to_vec()).map_err(|e| {
+                RayoError::CookieError(format!("Cookie value is not valid UTF-8: {e}"))
+            })
+        }
+    }
+}
+
+/// AES-128-CBC decryption with PKCS7 unpadding.
+fn decrypt_aes_128_cbc(ciphertext: &[u8], key: &[u8; 16]) -> Vec<u8> {
+    use aes::Aes128;
+    use aes::cipher::generic_array::GenericArray;
+    use aes::cipher::{BlockDecrypt, KeyInit};
+
+    let cipher = Aes128::new(GenericArray::from_slice(key));
+    let iv = [0u8; 16];
+    let mut plaintext = Vec::with_capacity(ciphertext.len());
+    let mut prev = iv;
+
+    for chunk in ciphertext.chunks_exact(16) {
+        let mut block = GenericArray::clone_from_slice(chunk);
+        cipher.decrypt_block(&mut block);
+        for (i, byte) in block.iter().enumerate() {
+            plaintext.push(byte ^ prev[i]);
+        }
+        prev.copy_from_slice(chunk);
+    }
+
+    // Remove PKCS7 padding
+    if let Some(&pad_len) = plaintext.last() {
+        let n = pad_len as usize;
+        if n > 0 && n <= 16 && plaintext.len() >= n {
+            let valid = plaintext[plaintext.len() - n..]
+                .iter()
+                .all(|&b| b == pad_len);
+            if valid {
+                plaintext.truncate(plaintext.len() - n);
+            }
+        }
+    }
+
+    plaintext
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_type_from_name() {
+        assert!(BrowserType::from_name("chrome").is_some());
+        assert!(BrowserType::from_name("Chrome").is_some());
+        assert!(BrowserType::from_name("CHROME").is_some());
+        assert!(BrowserType::from_name("arc").is_some());
+        assert!(BrowserType::from_name("brave").is_some());
+        assert!(BrowserType::from_name("edge").is_some());
+        assert!(BrowserType::from_name("chromium").is_some());
+        assert!(BrowserType::from_name("firefox").is_none());
+        assert!(BrowserType::from_name("safari").is_none());
+    }
+
+    #[test]
+    fn browser_type_display() {
+        assert_eq!(BrowserType::Chrome.to_string(), "Chrome");
+        assert_eq!(BrowserType::Arc.to_string(), "Arc");
+    }
+
+    #[test]
+    fn decrypt_known_value() {
+        // AES-128-CBC with key=0x00*16, IV=0x00*16
+        // Plaintext "hello" with PKCS7 padding (11 bytes of 0x0b):
+        //   [104, 101, 108, 108, 111, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]
+        // After AES-128-ECB encrypt of that padded block, XOR with IV (zeros) = same as ECB.
+        // We can verify the round-trip by encrypting then decrypting.
+        use aes::Aes128;
+        use aes::cipher::generic_array::GenericArray;
+        use aes::cipher::{BlockEncrypt, KeyInit};
+
+        let key = [0u8; 16];
+        let cipher = Aes128::new(GenericArray::from_slice(&key));
+
+        // "hello" + PKCS7 padding
+        let padded = *b"hello\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b";
+        let mut block = GenericArray::clone_from_slice(&padded);
+        cipher.encrypt_block(&mut block);
+        let ciphertext: Vec<u8> = block.to_vec();
+
+        // Decrypt should recover "hello"
+        let plaintext = decrypt_aes_128_cbc(&ciphertext, &key);
+        assert_eq!(plaintext, b"hello");
+
+        // Full cookie format: "v10" prefix + ciphertext
+        let mut encrypted = b"v10".to_vec();
+        encrypted.extend_from_slice(&ciphertext);
+        let result = decrypt_cookie_value(&encrypted, &key).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn decrypt_unknown_prefix_falls_back_to_raw() {
+        let key = [0u8; 16];
+        let raw = b"plaintext_value";
+        let result = decrypt_cookie_value(raw, &key).unwrap();
+        assert_eq!(result, "plaintext_value");
+    }
+}

--- a/crates/rayo-core/src/lib.rs
+++ b/crates/rayo-core/src/lib.rs
@@ -22,6 +22,8 @@ pub mod actions;
 pub mod batch;
 pub mod browser;
 pub mod cookie;
+#[cfg(feature = "cookie-import")]
+pub mod cookie_import;
 pub mod error;
 pub mod network;
 pub mod page_map;

--- a/crates/rayo-mcp/Cargo.toml
+++ b/crates/rayo-mcp/Cargo.toml
@@ -15,7 +15,7 @@ name = "rayo-mcp"
 path = "src/main.rs"
 
 [dependencies]
-rayo-core = { version = "0.1.0", path = "../rayo-core" }
+rayo-core = { version = "0.1.0", path = "../rayo-core", features = ["cookie-import"] }
 rayo-profiler = { version = "0.1.0", path = "../rayo-profiler" }
 rayo-rules = { version = "0.1.0", path = "../rayo-rules" }
 chromiumoxide = { workspace = true }

--- a/crates/rayo-mcp/src/server.rs
+++ b/crates/rayo-mcp/src/server.rs
@@ -282,11 +282,11 @@ impl RayoServer {
             ),
             Tool::new(
                 "rayo_cookie",
-                "Manage browser cookies. Actions: set (inject cookies), get (read, optional domain filter), clear (delete, optional domain filter), save (export to JSON file for persistence), load (import from JSON file to restore auth). Optional tab_id.",
+                "Manage browser cookies. Actions: set (inject cookies), get (read, optional domain filter), clear (delete, optional domain filter), save (export to JSON file), load (import from JSON file), import (read cookies from a real browser — requires browser: chrome/arc/brave/edge/chromium, optional domain filter, optional profile). Optional tab_id.",
                 json_schema(json!({
                     "type": "object",
                     "properties": {
-                        "action": { "type": "string", "enum": ["set", "get", "clear", "save", "load"] },
+                        "action": { "type": "string", "enum": ["set", "get", "clear", "save", "load", "import"] },
                         "cookies": {
                             "type": "array",
                             "description": "Cookies to set (required for 'set' action)",
@@ -306,8 +306,10 @@ impl RayoServer {
                                 "required": ["name", "value"]
                             }
                         },
-                        "domain": { "type": "string", "description": "Filter by domain (for 'get', 'clear', and 'save' actions)" },
+                        "domain": { "type": "string", "description": "Filter by domain (for 'get', 'clear', 'save', and 'import' actions)" },
                         "path": { "type": "string", "description": "File path for save/load actions (JSON format)" },
+                        "browser": { "type": "string", "enum": ["chrome", "arc", "brave", "edge", "chromium"], "description": "Browser to import cookies from (required for 'import' action)" },
+                        "profile": { "type": "string", "description": "Browser profile name for import (default: 'Default')" },
                         "tab_id": { "type": "string", "description": "Tab ID (default: active tab)" }
                     },
                     "required": ["action"]

--- a/crates/rayo-mcp/src/tools/mod.rs
+++ b/crates/rayo-mcp/src/tools/mod.rs
@@ -327,6 +327,104 @@ pub async fn handle_cookie(
                 )]))
             }
         }
+        "save" => {
+            let path = params
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| McpError::invalid_params("path is required for save", None))?;
+            let cookies = page.get_cookies().await.map_err(internal_err)?;
+            let domain_filter = params.get("domain").and_then(|v| v.as_str());
+            let filtered: Vec<_> = if let Some(domain) = domain_filter {
+                cookies
+                    .into_iter()
+                    .filter(|c| c.domain.contains(domain))
+                    .collect()
+            } else {
+                cookies
+            };
+            let count = filtered.len();
+            let json = serde_json::to_string_pretty(&filtered).map_err(|e| {
+                McpError::internal_error(format!("Failed to serialize cookies: {e}"), None)
+            })?;
+            std::fs::write(path, &json).map_err(|e| {
+                McpError::internal_error(format!("Failed to write {path}: {e}"), None)
+            })?;
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Saved {count} cookie(s) to {path}"
+            ))]))
+        }
+        "import" => {
+            let browser_name = params
+                .get("browser")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| McpError::invalid_params("browser is required for import", None))?;
+
+            let browser = rayo_core::cookie_import::BrowserType::from_name(browser_name)
+                .ok_or_else(|| {
+                    McpError::invalid_params(
+                        format!(
+                            "Unknown browser: {browser_name}. \
+                             Supported: chrome, arc, brave, edge, chromium"
+                        ),
+                        None,
+                    )
+                })?;
+
+            let domain = params.get("domain").and_then(|v| v.as_str());
+            let profile = params.get("profile").and_then(|v| v.as_str());
+
+            let imported = rayo_core::cookie_import::import_cookies(browser, domain, profile)
+                .map_err(internal_err)?;
+
+            let count = imported.len();
+            page.set_cookies(imported).await.map_err(internal_err)?;
+
+            let domain_msg = domain
+                .map(|d| format!(" for domain '{d}'"))
+                .unwrap_or_default();
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Imported {count} cookie(s) from {browser_name}{domain_msg}"
+            ))]))
+        }
+        "load" => {
+            let path = params
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| McpError::invalid_params("path is required for load", None))?;
+            let data = std::fs::read_to_string(path).map_err(|e| {
+                McpError::internal_error(format!("Failed to read {path}: {e}"), None)
+            })?;
+            let cookie_infos: Vec<rayo_core::CookieInfo> = serde_json::from_str(&data)
+                .map_err(|e| McpError::invalid_params(format!("Invalid cookie file: {e}"), None))?;
+            let cookies: Vec<rayo_core::SetCookie> = cookie_infos
+                .into_iter()
+                .map(|c| rayo_core::SetCookie {
+                    name: c.name,
+                    value: c.value,
+                    domain: Some(c.domain),
+                    path: Some(c.path),
+                    url: None,
+                    secure: Some(c.secure),
+                    http_only: Some(c.http_only),
+                    same_site: c.same_site.as_deref().and_then(|s| match s {
+                        "Strict" => Some(rayo_core::SameSite::Strict),
+                        "Lax" => Some(rayo_core::SameSite::Lax),
+                        "None" => Some(rayo_core::SameSite::None),
+                        _ => None,
+                    }),
+                    expires: if c.expires > 0.0 {
+                        Some(c.expires)
+                    } else {
+                        None
+                    },
+                })
+                .collect();
+            let count = cookies.len();
+            page.set_cookies(cookies).await.map_err(internal_err)?;
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Loaded {count} cookie(s) from {path}"
+            ))]))
+        }
         _ => Err(McpError::invalid_params(
             format!("Unknown cookie action: {action}"),
             None,


### PR DESCRIPTION
## Summary

- **New `import` action on `rayo_cookie`** — reads cookies directly from Chrome, Arc, Brave, Edge, or Chromium by decrypting their SQLite cookie databases. Supports macOS Keychain and Linux default password decryption (AES-128-CBC with PBKDF2-HMAC-SHA1 key derivation).
- **New `save`/`load` actions on `rayo_cookie`** — persist cookies to JSON files and restore them later, enabling session reuse across runs without re-importing.
- **Feature-gated** — cookie import lives behind a `cookie-import` Cargo feature in `rayo-core`, enabled by default in `rayo-mcp`. No new dependencies unless the feature is active.

## What it does

AI agents often need to interact with authenticated pages. Today that means manually exporting cookies or logging in through the headless browser. With `rayo_cookie import`, agents can pull cookies from whatever browser the user already has open:

```json
{ "tool": "rayo_cookie", "action": "import", "browser": "chrome", "domain": "github.com" }
```

This reads the Chrome cookie database, decrypts the values, and injects them into the headless browser — instant auth without any login flow.

## Implementation

- `rayo-core/src/cookie_import.rs` — new module: `BrowserType` enum, profile discovery, SQLite reading, AES-128-CBC decryption, Chrome epoch conversion
- `rayo-core/Cargo.toml` — `cookie-import` feature with optional deps (`rusqlite`, `aes`, `pbkdf2`, `sha1`, `hmac`)
- `rayo-mcp/src/server.rs` — updated `rayo_cookie` tool schema with `import`, `save`, `load` actions
- `rayo-mcp/src/tools/mod.rs` — handler implementations for all three new actions

## Test plan

- [x] Unit tests for `BrowserType::from_name`, display, AES decrypt round-trip, unknown prefix fallback
- [ ] Manual test: import cookies from Chrome on macOS, verify authenticated page loads
- [ ] Manual test: save/load round-trip preserves all cookie fields
- [ ] Manual test: domain filter narrows import to specific sites
- [ ] Verify feature gate: `cargo build -p rayo-core` without `cookie-import` flag compiles without SQLite deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)