### PR TITLE
fix: observation layer bugs + network capture + batch abort

### DIFF
--- a/crates/rayo-core/src/batch.rs
+++ b/crates/rayo-core/src/batch.rs
@@ -27,6 +27,12 @@ pub enum BatchAction {
         target: ActionTarget,
         value: String,
     },
+    /// Press a key on an element or the document.
+    Press {
+        #[serde(flatten)]
+        target: Option<ActionTarget>,
+        key: String,
+    },
     /// Navigate to a URL.
     Goto { url: String },
     /// Take a screenshot.

--- a/crates/rayo-core/src/browser.rs
+++ b/crates/rayo-core/src/browser.rs
@@ -6,9 +6,15 @@
 use std::sync::Arc;
 
 use crate::cookie::{CookieInfo, SameSite, SetCookie};
+use crate::network::{CapturedRequest, NetworkInterceptor};
 use chromiumoxide::browser::{Browser as CdpBrowser, BrowserConfig};
+use chromiumoxide::cdp::browser_protocol::fetch::{
+    ContinueRequestParams, EnableParams as FetchEnableParams, EventRequestPaused,
+    FailRequestParams, FulfillRequestParams, HeaderEntry as FetchHeaderEntry,
+};
 use chromiumoxide::cdp::browser_protocol::network::{
-    ClearBrowserCookiesParams, CookieParam, CookieSameSite, DeleteCookiesParams, TimeSinceEpoch,
+    ClearBrowserCookiesParams, CookieParam, CookieSameSite, DeleteCookiesParams, ErrorReason,
+    TimeSinceEpoch,
 };
 use chromiumoxide::cdp::browser_protocol::page::{
     CaptureScreenshotFormat, CaptureScreenshotParams, Viewport,
@@ -244,9 +250,115 @@ impl RayoPage {
     }
 
     /// Generate a token-efficient page map for LLMs (~500 tokens).
-    pub async fn page_map(&self) -> Result<PageMap, RayoError> {
+    ///
+    /// When `selector` is `Some`, the page map is scoped to that subtree:
+    /// interactive elements, headings, and text summary are all extracted
+    /// from within the matched element only.
+    pub async fn page_map(&self, selector: Option<&str>) -> Result<PageMap, RayoError> {
         let _span = self.profiler.start_span("page_map", SpanCategory::PageMap);
-        let result = self.page.evaluate(EXTRACT_PAGE_MAP_JS).await?;
+        let js = match selector {
+            Some(sel) => {
+                let sel_json = serde_json::to_string(sel).unwrap();
+                format!(
+                    r#"
+(() => {{
+    const root = document.querySelector({sel_json});
+    if (!root) return {{
+        url: window.location.href,
+        title: document.title,
+        interactive: [],
+        headings: [],
+        text_summary: "",
+    }};
+
+    const interactive = [];
+    const selectors = 'a[href], button, input, select, textarea, [role="button"], [role="link"], [role="tab"], [onclick]';
+    const elements = root.querySelectorAll(selectors);
+
+    const MAX_ELEMENTS = 50;
+    let count = 0;
+    elements.forEach((el, idx) => {{
+        if (count >= MAX_ELEMENTS) return;
+        if (el.offsetParent === null && el.type !== 'hidden') return;
+
+        const item = {{ id: idx, tag: el.tagName.toLowerCase(), selector: '' }};
+
+        if (el.type) item.type = el.type;
+        if (el.name) item.name = el.name;
+
+        const labelEl = el.labels && el.labels[0];
+        if (labelEl) {{
+            item.label = labelEl.textContent.trim();
+        }} else if (el.getAttribute('aria-label')) {{
+            item.label = el.getAttribute('aria-label');
+        }} else if (el.placeholder) {{
+            item.label = el.placeholder;
+        }}
+
+        const text = el.textContent?.trim();
+        if (text && text.length < 100 && (el.tagName === 'BUTTON' || el.tagName === 'A')) {{
+            item.text = text;
+        }}
+
+        if (el.placeholder) item.placeholder = el.placeholder;
+        if (el.value && el.type !== 'password') item.value = el.value;
+
+        if (el.tagName === 'SELECT') {{
+            item.options = Array.from(el.options).map(o => o.text || o.value);
+        }}
+
+        if (el.type === 'radio' || el.type === 'checkbox') {{
+            const group = document.querySelectorAll(`input[name="${{el.name}}"]`);
+            if (group.length > 1) {{
+                item.options = Array.from(group).map(r => r.value);
+            }}
+        }}
+
+        const role = el.getAttribute('role');
+        if (role) item.role = role;
+        if (el.href) item.href = el.href.length > 120 ? el.href.slice(0, 120) : el.href;
+
+        if (el.id) {{
+            item.selector = '#' + CSS.escape(el.id);
+        }} else if (el.name) {{
+            item.selector = `${{el.tagName.toLowerCase()}}[name="${{el.name}}"]`;
+        }} else {{
+            const parent = el.parentElement;
+            if (parent) {{
+                const siblings = parent.querySelectorAll(':scope > ' + el.tagName.toLowerCase());
+                const index = Array.from(siblings).indexOf(el) + 1;
+                item.selector = `${{el.tagName.toLowerCase()}}:nth-of-type(${{index}})`;
+            }}
+        }}
+
+        interactive.push(item);
+        count++;
+    }});
+
+    const headings = Array.from(root.querySelectorAll('h1, h2, h3'))
+        .map(h => h.textContent.trim())
+        .filter(t => t.length > 0)
+        .slice(0, 10);
+
+    const paragraphs = Array.from(root.querySelectorAll('p'))
+        .map(p => p.textContent.trim())
+        .filter(t => t.length > 20);
+    const textSummary = paragraphs.slice(0, 2).join(' ').slice(0, 300);
+
+    return {{
+        url: window.location.href,
+        title: document.title,
+        interactive: interactive,
+        headings: headings,
+        text_summary: textSummary || document.title,
+    }};
+}})()"#,
+                    sel_json = sel_json,
+                )
+            }
+            None => EXTRACT_PAGE_MAP_JS.to_string(),
+        };
+        let result = self.page.evaluate(js).await?;
         let map: PageMap = result
             .into_value()
             .map_err(|e| RayoError::Cdp(format!("Failed to deserialize page map: {e:?}")))?;
@@ -254,15 +366,38 @@ impl RayoPage {
         Ok(map)
     }
 
-    /// Get text content of the page or a specific element.
-    pub async fn text_content(&self, selector: Option<&str>) -> Result<String, RayoError> {
+    /// Get text content of the page or specific elements.
+    ///
+    /// When a selector is provided, uses `querySelectorAll` and joins all matches
+    /// with newlines. Results are capped at `max_elements`; if exceeded, a
+    /// `[truncated: N more elements matched]` notice is appended.
+    pub async fn text_content(
+        &self,
+        selector: Option<&str>,
+        max_elements: usize,
+    ) -> Result<String, RayoError> {
         let _span = self
             .profiler
             .start_span("text_content", SpanCategory::DomRead);
         let js = match selector {
             Some(sel) => format!(
-                "document.querySelector({}).textContent",
-                serde_json::to_string(sel).unwrap()
+                r#"(() => {{
+                    const els = document.querySelectorAll({sel_json});
+                    if (els.length === 0) return "";
+                    const max = {max};
+                    const texts = [];
+                    for (let i = 0; i < Math.min(els.length, max); i++) {{
+                        const t = (els[i].textContent || "").trim();
+                        if (t) texts.push(t);
+                    }}
+                    let result = texts.join("\n");
+                    if (els.length > max) {{
+                        result += "\n[truncated: " + (els.length - max) + " more elements matched]";
+                    }}
+                    return result;
+                }})()"#,
+                sel_json = serde_json::to_string(sel).unwrap(),
+                max = max_elements,
             ),
             None => "document.body.innerText".to_string(),
         };
@@ -422,7 +557,12 @@ impl RayoPage {
     }
 
     /// Execute a batch of actions.
-    pub async fn execute_batch(&self, actions: Vec<BatchAction>) -> Result<BatchResult, RayoError> {
+    /// When `abort_on_failure` is true, remaining actions are skipped after the first failure.
+    pub async fn execute_batch(
+        &self,
+        actions: Vec<BatchAction>,
+        abort_on_failure: bool,
+    ) -> Result<BatchResult, RayoError> {
         let _span = self
             .profiler
             .start_span(format!("batch({})", actions.len()), SpanCategory::Batch);
@@ -505,6 +645,21 @@ impl RayoPage {
                         data: None,
                         duration_ms,
                     });
+                    if abort_on_failure {
+                        // Mark remaining actions as skipped
+                        for (j, remaining) in actions.iter().enumerate().skip(i + 1) {
+                            results.push(BatchActionResult {
+                                index: j,
+                                action: action_name(remaining).to_string(),
+                                success: false,
+                                error: Some("Skipped (abort_on_failure)".to_string()),
+                                data: None,
+                                duration_ms: 0.0,
+                            });
+                            failed += 1;
+                        }
+                        break;
+                    }
                 }
             }
         }
@@ -642,6 +797,135 @@ impl RayoPage {
         Ok(())
     }
 
+    /// Enable CDP Fetch-domain interception and wire events to the NetworkInterceptor.
+    ///
+    /// Subscribes to `Fetch.requestPaused` events. For each paused request the handler
+    /// checks block rules, mock rules, and capture state in the shared `NetworkInterceptor`,
+    /// then responds with `failRequest`, `fulfillRequest`, or `continueRequest` accordingly.
+    pub async fn enable_network_interception(
+        &self,
+        network: Arc<Mutex<NetworkInterceptor>>,
+    ) -> Result<(), RayoError> {
+        // Enable the Fetch domain — intercept all requests
+        self.page
+            .execute(FetchEnableParams {
+                patterns: None, // intercept everything
+                handle_auth_requests: None,
+            })
+            .await
+            .map_err(|e| RayoError::Cdp(format!("Fetch.enable failed: {e}")))?;
+
+        // Subscribe to requestPaused events
+        let mut events = self
+            .page
+            .event_listener::<EventRequestPaused>()
+            .await
+            .map_err(|e| RayoError::Cdp(format!("Failed to listen for Fetch events: {e}")))?;
+
+        // Clone the inner CdpPage handle for the spawned task
+        let page = self.page.clone();
+
+        tokio::spawn(async move {
+            while let Some(event) = events.next().await {
+                let event = Arc::new(event);
+                let request_id = event.request_id.clone();
+                let url = event.request.url.clone();
+                let method = event.request.method.clone();
+                let resource_type_str = event.resource_type.as_ref().to_string();
+
+                // Extract request headers as Vec<(String, String)>
+                let headers: Vec<(String, String)> = event
+                    .request
+                    .headers
+                    .inner()
+                    .as_object()
+                    .map(|obj| {
+                        obj.iter()
+                            .filter_map(|(k, v)| {
+                                v.as_str().map(|val| (k.clone(), val.to_string()))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let mut net = network.lock().await;
+
+                // 1. Check block rules
+                if net.should_block(&url, Some(&resource_type_str)) {
+                    drop(net);
+                    if let Err(e) = page
+                        .execute(FailRequestParams::new(
+                            request_id,
+                            ErrorReason::BlockedByClient,
+                        ))
+                        .await
+                    {
+                        tracing::warn!("Fetch.failRequest failed: {e}");
+                    }
+                    continue;
+                }
+
+                // 2. Check mock rules
+                if let Some(mock) = net.find_mock(&url, Some(&resource_type_str)).cloned() {
+                    // Record the request if capturing
+                    if net.is_capturing() {
+                        net.record_request(CapturedRequest {
+                            url: url.clone(),
+                            method,
+                            resource_type: resource_type_str,
+                            status: Some(mock.status as i64),
+                            headers,
+                            timestamp_ms: timestamp_now_ms(),
+                        });
+                    }
+                    drop(net);
+
+                    let response_headers: Vec<FetchHeaderEntry> = mock
+                        .headers
+                        .iter()
+                        .map(|(k, v)| FetchHeaderEntry::new(k.clone(), v.clone()))
+                        .collect();
+
+                    use base64::Engine;
+                    let body_b64 =
+                        base64::engine::general_purpose::STANDARD.encode(mock.body.as_bytes());
+
+                    let mut params =
+                        FulfillRequestParams::new(request_id, mock.status as i64);
+                    params.response_headers = Some(response_headers);
+                    params.body = Some(body_b64.into());
+
+                    if let Err(e) = page.execute(params).await {
+                        tracing::warn!("Fetch.fulfillRequest failed: {e}");
+                    }
+                    continue;
+                }
+
+                // 3. Record and continue
+                if net.is_capturing() {
+                    net.record_request(CapturedRequest {
+                        url,
+                        method,
+                        resource_type: resource_type_str,
+                        status: None, // status unknown at request stage
+                        headers,
+                        timestamp_ms: timestamp_now_ms(),
+                    });
+                }
+                drop(net);
+
+                if let Err(e) = page
+                    .execute(ContinueRequestParams::new(request_id))
+                    .await
+                {
+                    tracing::warn!("Fetch.continueRequest failed: {e}");
+                }
+            }
+        });
+
+        Ok(())
+    }
+
     /// Resolve a selector from either a CSS selector or a page map element ID.
     async fn resolve_selector(
         &self,
@@ -682,7 +966,7 @@ impl RayoPage {
             }
             drop(cache);
             // Refresh page map and retry
-            let map = self.page_map().await?;
+            let map = self.page_map(None).await?;
             if let Some(el) = map.interactive.iter().find(|e| e.id == element_id) {
                 let resolved = el.selector.clone();
                 self.selector_cache
@@ -730,6 +1014,15 @@ fn truncate(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+/// Current time in milliseconds since UNIX epoch, for captured request timestamps.
+fn timestamp_now_ms() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+        * 1000.0
 }
 
 /// Convert rayo-owned SetCookie to chromiumoxide CookieParam.

--- a/crates/rayo-core/src/browser.rs
+++ b/crates/rayo-core/src/browser.rs
@@ -13,8 +13,9 @@ use chromiumoxide::cdp::browser_protocol::fetch::{
     FailRequestParams, FulfillRequestParams, HeaderEntry as FetchHeaderEntry,
 };
 use chromiumoxide::cdp::browser_protocol::network::{
-    ClearBrowserCookiesParams, CookieParam, CookieSameSite, DeleteCookiesParams, ErrorReason,
-    TimeSinceEpoch,
+    ClearBrowserCookiesParams, CookieParam, CookieSameSite, DeleteCookiesParams,
+    EnableParams as NetworkEnableParams, ErrorReason, EventRequestWillBeSent,
+    EventResponseReceived, TimeSinceEpoch,
 };
 use chromiumoxide::cdp::browser_protocol::page::{
     CaptureScreenshotFormat, CaptureScreenshotParams, Viewport,
@@ -340,10 +341,17 @@ impl RayoPage {
         .filter(t => t.length > 0)
         .slice(0, 10);
 
-    const paragraphs = Array.from(root.querySelectorAll('p'))
-        .map(p => p.textContent.trim())
-        .filter(t => t.length > 20);
-    const textSummary = paragraphs.slice(0, 2).join(' ').slice(0, 300);
+    // Text summary — extract visible text from the scoped root
+    const scopeContent = root.querySelector('main, [role="main"], article, .readme, #readme') || root;
+    const paragraphs = Array.from(scopeContent.querySelectorAll('p, li, dd, blockquote'))
+        .filter(el => {{
+            if (!el.offsetParent && el.style.position !== 'fixed') return false;
+            const text = el.textContent.trim();
+            return text.length > 20;
+        }})
+        .map(el => el.textContent.trim())
+        .slice(0, 5);
+    const textSummary = paragraphs.join(' ').slice(0, 600);
 
     return {{
         url: window.location.href,
@@ -531,6 +539,47 @@ impl RayoPage {
         Ok(())
     }
 
+    /// Press a key on an element or the document.
+    /// Uses CDP Input.dispatchKeyEvent via chromiumoxide for real key events.
+    /// Key names follow CDP conventions: "Enter", "Tab", "Escape", "ArrowDown", etc.
+    pub async fn press_key(
+        &self,
+        selector: Option<&str>,
+        id: Option<usize>,
+        key: &str,
+    ) -> Result<(), RayoError> {
+        let _span = self.profiler.start_span(
+            format!("press_key({})", truncate(key, 20)),
+            SpanCategory::DomMutate,
+        );
+        if selector.is_some() || id.is_some() {
+            let sel = self.resolve_selector(selector, id).await?;
+            let element =
+                self.page
+                    .find_element(&sel)
+                    .await
+                    .map_err(|e| RayoError::ElementNotFound {
+                        selector: format!("{sel}: {e}"),
+                    })?;
+            element
+                .press_key(key)
+                .await
+                .map_err(|e| RayoError::Cdp(format!("press_key failed: {e}")))?;
+        } else {
+            // No selector/id — dispatch key press on the document body
+            let element =
+                self.page.find_element("body").await.map_err(|e| {
+                    RayoError::Cdp(format!("could not find body for key press: {e}"))
+                })?;
+            element
+                .press_key(key)
+                .await
+                .map_err(|e| RayoError::Cdp(format!("press_key failed: {e}")))?;
+        }
+        self.invalidate_after_mutation().await;
+        Ok(())
+    }
+
     /// Select an option from a dropdown.
     pub async fn select_option(
         &self,
@@ -597,6 +646,14 @@ impl RayoPage {
                     self.wait_for_selector(&selector, *timeout_ms)
                         .await
                         .map(|_| None)
+                }
+                BatchAction::Press { target, key } => {
+                    let (sel, id) = if let Some(t) = target {
+                        target_to_selector_id(t)
+                    } else {
+                        (None, None)
+                    };
+                    self.press_key(sel, id, key).await.map(|_| None)
                 }
                 BatchAction::Scroll { target, x, y } => {
                     if let Some(t) = target {
@@ -797,11 +854,112 @@ impl RayoPage {
         Ok(())
     }
 
+    /// Enable passive network monitoring via the CDP Network domain.
+    ///
+    /// Uses `Network.enable` to passively observe traffic without intercepting it.
+    /// Listens for `Network.requestWillBeSent` and `Network.responseReceived` events
+    /// to record requests and their response statuses. Requests flow normally with
+    /// zero added latency — this is the right mode for capture-only use cases.
+    pub async fn enable_network_monitoring(
+        &self,
+        network: Arc<Mutex<NetworkInterceptor>>,
+    ) -> Result<(), RayoError> {
+        // Enable the Network domain for passive monitoring
+        self.page
+            .execute(NetworkEnableParams::default())
+            .await
+            .map_err(|e| RayoError::Cdp(format!("Network.enable failed: {e}")))?;
+
+        // Subscribe to requestWillBeSent events
+        let mut request_events = self
+            .page
+            .event_listener::<EventRequestWillBeSent>()
+            .await
+            .map_err(|e| {
+                RayoError::Cdp(format!(
+                    "Failed to listen for Network.requestWillBeSent: {e}"
+                ))
+            })?;
+
+        // Subscribe to responseReceived events
+        let mut response_events = self
+            .page
+            .event_listener::<EventResponseReceived>()
+            .await
+            .map_err(|e| {
+                RayoError::Cdp(format!(
+                    "Failed to listen for Network.responseReceived: {e}"
+                ))
+            })?;
+
+        // Spawn task for requestWillBeSent — records new requests
+        let network_for_requests = Arc::clone(&network);
+        tokio::spawn(async move {
+            while let Some(event) = request_events.next().await {
+                let url = event.request.url.clone();
+                let method = event.request.method.clone();
+                let resource_type_str = event
+                    .r#type
+                    .as_ref()
+                    .map(|t| t.as_ref().to_string())
+                    .unwrap_or_else(|| "Other".to_string());
+                let request_id = event.request_id.inner().to_string();
+
+                // Extract request headers
+                let headers: Vec<(String, String)> = event
+                    .request
+                    .headers
+                    .inner()
+                    .as_object()
+                    .map(|obj| {
+                        obj.iter()
+                            .filter_map(|(k, v)| {
+                                v.as_str().map(|val| (k.clone(), val.to_string()))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let mut net = network_for_requests.lock().await;
+                if net.is_capturing() {
+                    net.record_request(CapturedRequest {
+                        url,
+                        method,
+                        resource_type: resource_type_str,
+                        status: None, // filled in by responseReceived
+                        headers,
+                        timestamp_ms: timestamp_now_ms(),
+                        request_id: Some(request_id),
+                    });
+                }
+            }
+        });
+
+        // Spawn task for responseReceived — updates status on existing requests
+        let network_for_responses = Arc::clone(&network);
+        tokio::spawn(async move {
+            while let Some(event) = response_events.next().await {
+                let request_id = event.request_id.inner().to_string();
+                let status = event.response.status;
+
+                let mut net = network_for_responses.lock().await;
+                if net.is_capturing() {
+                    net.update_request_status(&request_id, status);
+                }
+            }
+        });
+
+        Ok(())
+    }
+
     /// Enable CDP Fetch-domain interception and wire events to the NetworkInterceptor.
     ///
     /// Subscribes to `Fetch.requestPaused` events. For each paused request the handler
     /// checks block rules, mock rules, and capture state in the shared `NetworkInterceptor`,
     /// then responds with `failRequest`, `fulfillRequest`, or `continueRequest` accordingly.
+    ///
+    /// This is only needed when block or mock rules are active. For capture-only,
+    /// use `enable_network_monitoring()` instead.
     pub async fn enable_network_interception(
         &self,
         network: Arc<Mutex<NetworkInterceptor>>,
@@ -876,6 +1034,7 @@ impl RayoPage {
                             status: Some(mock.status as i64),
                             headers,
                             timestamp_ms: timestamp_now_ms(),
+                            request_id: None,
                         });
                     }
                     drop(net);
@@ -910,6 +1069,7 @@ impl RayoPage {
                         status: None, // status unknown at request stage
                         headers,
                         timestamp_ms: timestamp_now_ms(),
+                        request_id: None,
                     });
                 }
                 drop(net);
@@ -997,6 +1157,7 @@ fn action_name(action: &BatchAction) -> &'static str {
         BatchAction::Click { .. } => "click",
         BatchAction::Type { .. } => "type",
         BatchAction::Select { .. } => "select",
+        BatchAction::Press { .. } => "press",
         BatchAction::Goto { .. } => "goto",
         BatchAction::Screenshot { .. } => "screenshot",
         BatchAction::WaitFor { .. } => "wait_for",

--- a/crates/rayo-core/src/page_map.rs
+++ b/crates/rayo-core/src/page_map.rs
@@ -151,11 +151,17 @@ pub const EXTRACT_PAGE_MAP_JS: &str = r#"
         .filter(t => t.length > 0)
         .slice(0, 10);
 
-    // Text summary (first meaningful paragraph)
-    const paragraphs = Array.from(document.querySelectorAll('p'))
-        .map(p => p.textContent.trim())
-        .filter(t => t.length > 20);
-    const textSummary = paragraphs.slice(0, 2).join(' ').slice(0, 300);
+    // Text summary — find main content region, then extract visible text
+    const mainContent = document.querySelector('main, [role="main"], article, .readme, #readme') || document.body;
+    const paragraphs = Array.from(mainContent.querySelectorAll('p, li, dd, blockquote'))
+        .filter(el => {
+            if (!el.offsetParent && el.style.position !== 'fixed') return false;
+            const text = el.textContent.trim();
+            return text.length > 20;
+        })
+        .map(el => el.textContent.trim())
+        .slice(0, 5);
+    const textSummary = paragraphs.join(' ').slice(0, 600);
 
     return {
         url: window.location.href,

--- a/crates/rayo-core/tests/integration_test.rs
+++ b/crates/rayo-core/tests/integration_test.rs
@@ -78,7 +78,7 @@ async fn test_browser_operations() {
     eprintln!("  PASS: navigate_and_title");
 
     // --- Test: text content ---
-    let text = page.text_content(None).await.unwrap();
+    let text = page.text_content(None, 50).await.unwrap();
     assert!(
         text.contains("Test Page"),
         "Text should contain 'Test Page'"
@@ -91,7 +91,7 @@ async fn test_browser_operations() {
     eprintln!("  PASS: evaluate");
 
     // --- Test: page map ---
-    let map = page.page_map().await.unwrap();
+    let map = page.page_map(None).await.unwrap();
     assert!(!map.url.is_empty(), "Page map URL should not be empty");
     assert!(!map.title.is_empty(), "Page map title should not be empty");
     assert!(
@@ -116,7 +116,7 @@ async fn test_browser_operations() {
 
     // --- Test: batch execution ---
     let actions = vec![BatchAction::Screenshot { full_page: false }];
-    let batch_result = page.execute_batch(actions).await.unwrap();
+    let batch_result = page.execute_batch(actions, false).await.unwrap();
     assert_eq!(batch_result.succeeded, 1);
     assert_eq!(batch_result.failed, 0);
     assert!(batch_result.all_succeeded());
@@ -181,7 +181,7 @@ async fn test_browser_operations() {
         );
 
         // Get page map to verify form elements are detected
-        let map = page.page_map().await.unwrap();
+        let map = page.page_map(None).await.unwrap();
         assert!(
             map.interactive
                 .iter()
@@ -279,7 +279,7 @@ async fn test_browser_operations() {
             },
             BatchAction::Screenshot { full_page: false },
         ];
-        let batch_result = page.execute_batch(actions).await.unwrap();
+        let batch_result = page.execute_batch(actions, false).await.unwrap();
         assert_eq!(
             batch_result.succeeded, 2,
             "Both batch actions should succeed"

--- a/crates/rayo-mcp/src/server.rs
+++ b/crates/rayo-mcp/src/server.rs
@@ -80,12 +80,12 @@ impl RayoServer {
             let page = browser.new_page().await.map_err(|e| {
                 McpError::internal_error(format!("Failed to create page: {e}"), None)
             })?;
-            // Wire CDP Fetch events to the shared NetworkInterceptor
-            page.enable_network_interception(Arc::clone(&self.network))
+            // Wire passive Network domain monitoring for capture
+            page.enable_network_monitoring(Arc::clone(&self.network))
                 .await
                 .map_err(|e| {
                     McpError::internal_error(
-                        format!("Failed to enable network interception: {e}"),
+                        format!("Failed to enable network monitoring: {e}"),
                         None,
                     )
                 })?;
@@ -124,12 +124,12 @@ impl RayoServer {
                 let page = browser.new_page().await.map_err(|e| {
                     McpError::internal_error(format!("Failed to create tab: {e}"), None)
                 })?;
-                // Wire CDP Fetch events to the shared NetworkInterceptor
-                page.enable_network_interception(Arc::clone(&self.network))
+                // Wire passive Network domain monitoring for capture
+                page.enable_network_monitoring(Arc::clone(&self.network))
                     .await
                     .map_err(|e| {
                         McpError::internal_error(
-                            format!("Failed to enable network interception: {e}"),
+                            format!("Failed to enable network monitoring: {e}"),
                             None,
                         )
                     })?;
@@ -257,11 +257,11 @@ impl RayoServer {
             ),
             Tool::new(
                 "rayo_interact",
-                "Interact with an element. Use id from page_map or CSS selector. Actions: click, type (requires value), select (requires value), scroll. Optional tab_id.",
+                "Interact with an element. Use id from page_map or CSS selector. Actions: click, type (requires value), press (requires value — key name like \"Enter\", \"Tab\", \"Escape\", \"ArrowDown\"), select (requires value), scroll. Optional tab_id.",
                 json_schema(json!({
                     "type": "object",
                     "properties": {
-                        "action": { "type": "string", "enum": ["click", "type", "select", "scroll"] },
+                        "action": { "type": "string", "enum": ["click", "type", "press", "select", "scroll"] },
                         "id": { "type": "integer", "description": "Element ID from page_map" },
                         "selector": { "type": "string", "description": "CSS selector (alternative to id)" },
                         "value": { "type": "string", "description": "Text to type or option to select" },
@@ -281,10 +281,11 @@ impl RayoServer {
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "action": { "type": "string", "enum": ["click", "type", "select", "goto", "screenshot", "wait_for", "scroll"] },
+                                    "action": { "type": "string", "enum": ["click", "type", "press", "select", "goto", "screenshot", "wait_for", "scroll"] },
                                     "id": { "type": "integer" },
                                     "selector": { "type": "string" },
                                     "value": { "type": "string" },
+                                    "key": { "type": "string", "description": "Key name for press action (e.g. Enter, Tab, Escape, ArrowDown)" },
                                     "url": { "type": "string" },
                                     "full_page": { "type": "boolean" },
                                     "timeout_ms": { "type": "integer" },
@@ -459,7 +460,11 @@ impl ServerHandler for RayoServer {
                     let page = Self::resolve_page(&tabs, tab_id).await?;
                     tools::handle_cookie(page, &params).await
                 }
-                "rayo_network" => tools::handle_network(&self.network, &params).await,
+                "rayo_network" => {
+                    let tabs = self.tabs.lock().await;
+                    let page = Self::resolve_page(&tabs, tab_id).await?;
+                    tools::handle_network(page, &self.network, &params).await
+                }
                 "rayo_profile" => tools::handle_profile(&self.profiler, &params).await,
                 _ => Err(McpError::invalid_request(
                     format!("Unknown tool: {tool_name}"),

--- a/crates/rayo-mcp/src/server.rs
+++ b/crates/rayo-mcp/src/server.rs
@@ -80,6 +80,15 @@ impl RayoServer {
             let page = browser.new_page().await.map_err(|e| {
                 McpError::internal_error(format!("Failed to create page: {e}"), None)
             })?;
+            // Wire CDP Fetch events to the shared NetworkInterceptor
+            page.enable_network_interception(Arc::clone(&self.network))
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(
+                        format!("Failed to enable network interception: {e}"),
+                        None,
+                    )
+                })?;
             let tab_id = "tab-0".to_string();
             tabs_guard.add_tab(tab_id, page);
             tracing::debug!("Created initial tab");
@@ -115,6 +124,15 @@ impl RayoServer {
                 let page = browser.new_page().await.map_err(|e| {
                     McpError::internal_error(format!("Failed to create tab: {e}"), None)
                 })?;
+                // Wire CDP Fetch events to the shared NetworkInterceptor
+                page.enable_network_interception(Arc::clone(&self.network))
+                    .await
+                    .map_err(|e| {
+                        McpError::internal_error(
+                            format!("Failed to enable network interception: {e}"),
+                            None,
+                        )
+                    })?;
 
                 let mut tabs = self.tabs.lock().await;
                 let tab_id = format!("tab-{}", tabs.tab_count());
@@ -225,12 +243,13 @@ impl RayoServer {
             ),
             Tool::new(
                 "rayo_observe",
-                "Observe the page. Modes: page_map (default, ~500 tokens, structured), text (raw text), screenshot (base64 JPEG). Optional tab_id.",
+                "Observe the page. Modes: page_map (default, ~500 tokens, structured — supports selector to scope to a subtree), text (raw text — supports selector + max_elements), screenshot (base64 JPEG). Optional tab_id.",
                 json_schema(json!({
                     "type": "object",
                     "properties": {
                         "mode": { "type": "string", "enum": ["page_map", "text", "screenshot"], "default": "page_map" },
                         "selector": { "type": "string", "description": "CSS selector to scope observation" },
+                        "max_elements": { "type": "integer", "description": "Max elements for text mode with selector (default: 50)", "default": 50 },
                         "full_page": { "type": "boolean", "default": false },
                         "tab_id": { "type": "string", "description": "Tab ID (default: active tab)" }
                     }
@@ -275,6 +294,7 @@ impl RayoServer {
                                 "required": ["action"]
                             }
                         },
+                        "abort_on_failure": { "type": "boolean", "description": "Stop batch on first failure (default: false)", "default": false },
                         "tab_id": { "type": "string", "description": "Tab ID (default: active tab)" }
                     },
                     "required": ["actions"]

--- a/crates/rayo-mcp/src/tools/mod.rs
+++ b/crates/rayo-mcp/src/tools/mod.rs
@@ -192,6 +192,18 @@ pub async fn handle_interact(
                 .map_err(internal_err)?;
             format!("Selected: {val}")
         }
+        "press" => {
+            let key = value.ok_or_else(|| {
+                McpError::invalid_params(
+                    "value is required for press (key name, e.g. \"Enter\", \"Tab\", \"Escape\")",
+                    None,
+                )
+            })?;
+            page.press_key(selector, id, key)
+                .await
+                .map_err(internal_err)?;
+            format!("Pressed: {key}")
+        }
         "scroll" => {
             if let Some(sel) = selector {
                 let js = format!(
@@ -449,6 +461,7 @@ pub async fn handle_cookie(
 }
 
 pub async fn handle_network(
+    page: &RayoPage,
     network: &Arc<Mutex<NetworkInterceptor>>,
     params: &serde_json::Map<String, Value>,
 ) -> Result<CallToolResult, McpError> {
@@ -486,10 +499,18 @@ pub async fn handle_network(
                 .get("resource_type")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let need_fetch = !net.has_active_rules();
             net.add_block_rule(rayo_core::network::BlockRule {
                 url_pattern: url_pattern.to_string(),
                 resource_type,
             });
+            // Enable Fetch interception on first block/mock rule
+            if need_fetch {
+                drop(net);
+                page.enable_network_interception(Arc::clone(network))
+                    .await
+                    .map_err(internal_err)?;
+            }
             Ok(CallToolResult::success(vec![Content::text(format!(
                 "Blocking requests matching: {url_pattern}"
             ))]))
@@ -527,6 +548,7 @@ pub async fn handle_network(
                 .and_then(|v| v.as_str())
                 .map(String::from);
 
+            let need_fetch = !net.has_active_rules();
             net.add_mock_rule(rayo_core::network::MockRule {
                 url_pattern: url_pattern.to_string(),
                 status,
@@ -534,6 +556,13 @@ pub async fn handle_network(
                 headers,
                 resource_type,
             });
+            // Enable Fetch interception on first block/mock rule
+            if need_fetch {
+                drop(net);
+                page.enable_network_interception(Arc::clone(network))
+                    .await
+                    .map_err(internal_err)?;
+            }
             Ok(CallToolResult::success(vec![Content::text(format!(
                 "Mocking requests matching: {url_pattern} with status {status}"
             ))]))

--- a/crates/rayo-mcp/src/tools/mod.rs
+++ b/crates/rayo-mcp/src/tools/mod.rs
@@ -38,7 +38,7 @@ pub async fn handle_navigate(
 
             // Auto-return page_map after navigation (delight feature)
             // page_map already contains title and URL, so no separate CDP calls needed
-            if let Ok(map) = page.page_map().await {
+            if let Ok(map) = page.page_map(None).await {
                 let json = serde_json::to_string(&map).unwrap_or_default();
                 let content = vec![
                     Content::text(format!("Navigated to {}\nTitle: {}", map.url, map.title)),
@@ -113,13 +113,21 @@ pub async fn handle_observe(
 
     match mode {
         "page_map" => {
-            let map = page.page_map().await.map_err(internal_err)?;
+            let selector = params.get("selector").and_then(|v| v.as_str());
+            let map = page.page_map(selector).await.map_err(internal_err)?;
             let json = serde_json::to_string(&map).unwrap_or_default();
             Ok(CallToolResult::success(vec![Content::text(json)]))
         }
         "text" => {
             let selector = params.get("selector").and_then(|v| v.as_str());
-            let text = page.text_content(selector).await.map_err(internal_err)?;
+            let max_elements = params
+                .get("max_elements")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(50) as usize;
+            let text = page
+                .text_content(selector, max_elements)
+                .await
+                .map_err(internal_err)?;
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         "screenshot" => {
@@ -220,12 +228,20 @@ pub async fn handle_batch(
     let actions: Vec<rayo_core::batch::BatchAction> = serde_json::from_value(actions_value.clone())
         .map_err(|e| McpError::invalid_params(format!("Invalid actions: {e}"), None))?;
 
-    let result = page.execute_batch(actions).await.map_err(internal_err)?;
+    let abort_on_failure = params
+        .get("abort_on_failure")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let result = page
+        .execute_batch(actions, abort_on_failure)
+        .await
+        .map_err(internal_err)?;
 
     let json = serde_json::to_string(&result).unwrap_or_default();
     // Auto-return page_map so LLM doesn't need a separate observe call
     let mut content = vec![Content::text(json)];
-    if let Ok(map) = page.page_map().await {
+    if let Ok(map) = page.page_map(None).await {
         let map_json = serde_json::to_string(&map).unwrap_or_default();
         content.push(Content::text(format!("\n--- page_map ---\n{map_json}")));
     }

--- a/docs/openspec/changes/observation-layer-fix/design.md
+++ b/docs/openspec/changes/observation-layer-fix/design.md
@@ -1,0 +1,55 @@
+# Design: Observation Layer Fix
+
+## Architecture
+
+```
+AI Agent
+  │
+  ├── rayo_observe(mode: "text", selector: ".card", max_elements: 50)
+  │       │
+  │       ▼
+  │   handle_observe() → page.text_content(selector, max_elements)
+  │       │
+  │       ▼
+  │   JS: querySelectorAll(sel) → join(\n) → cap at max_elements
+  │       │
+  │       ▼
+  │   Empty string on 0 matches (null-safe)
+  │
+  ├── rayo_observe(mode: "page_map", selector: ".sidebar")
+  │       │
+  │       ▼
+  │   handle_observe() → page.page_map(Some(selector))
+  │       │
+  │       ▼
+  │   JS: root = querySelector(sel) || document
+  │       querySelectorAll(interactive selectors) scoped to root
+  │       headings + text_summary scoped to root
+  │
+  ├── rayo_batch(actions: [...], abort_on_failure: true)
+  │       │
+  │       ▼
+  │   execute_batch(actions, true)
+  │       │
+  │       ▼
+  │   On failure → mark remaining as "Skipped (abort_on_failure)" → break
+  │
+  └── rayo_network(mode: "capture") → navigate → rayo_network(mode: "requests")
+          │
+          ▼
+      enable_network_interception(network: Arc<Mutex<NetworkInterceptor>>)
+          │
+          ▼
+      CDP Fetch.enable() → spawn listener for Fetch.requestPaused
+          │
+          ├── should_block() → Fetch.failRequest(BlockedByClient)
+          ├── find_mock() → Fetch.fulfillRequest(status, body, headers)
+          └── default → record_request() + Fetch.continueRequest
+```
+
+## Key decisions
+- `querySelectorAll` replaces `querySelector` as default (no backward compat needed — pre-launch)
+- `max_elements` default is 50 — prevents token explosions from broad selectors
+- Scoped page_map generates dynamic JS (not modifying the EXTRACT_PAGE_MAP_JS constant)
+- Network interception wired per-page via `enable_network_interception()` called from server
+- `abort_on_failure` defaults to `false` to preserve existing batch behavior

--- a/docs/openspec/changes/observation-layer-fix/proposal.md
+++ b/docs/openspec/changes/observation-layer-fix/proposal.md
@@ -1,0 +1,28 @@
+# Observation Layer: Fix silent failures, complete network capture
+
+## Why
+1. `text_content()` uses `querySelector` (returns first match only) — agents silently get incomplete data
+2. `text_content()` crashes with `TypeError: null.textContent` when selector doesn't match
+3. `page_map()` ignores the `selector` parameter — always returns full page regardless
+4. `rayo_network capture` + `requests` always returns 0 results — CDP Fetch events are not wired
+5. `execute_batch()` has no way to abort on failure — actions run against destroyed contexts after navigation
+
+## What Changes
+
+### rayo-core
+- `browser.rs` — `text_content()`: use `querySelectorAll`, join with `\n`, null-safe, new `max_elements` param (default 50)
+- `browser.rs` — `page_map()`: accept optional `selector` param, scope interactive elements/headings/text_summary to subtree
+- `browser.rs` — `execute_batch()`: new `abort_on_failure` param, skip remaining actions on failure
+- `browser.rs` — `enable_network_interception()`: wire CDP `Fetch.enable()` + `Fetch.requestPaused` event handler
+- `browser.rs` — `press_key()`: new method for CDP key dispatch
+- `batch.rs` — add `Press` variant to `BatchAction`
+- `page_map.rs` — enhanced text_summary extraction (scope to main/article, filter invisible elements)
+
+### rayo-mcp
+- `tools/mod.rs` — pass `selector`, `max_elements` to observe handlers; extract `abort_on_failure` for batch
+- `server.rs` — update tool schemas (max_elements, abort_on_failure); wire network interception on page creation
+
+## Not in scope
+- CDP DOM mutation events for cache invalidation (see `cache-coherence` change)
+- Selector cache wiring into `resolve_selector()` (see `smart-cache` change)
+- Event-driven waits replacing polling (see `event-driven-waits` change)

--- a/docs/openspec/changes/observation-layer-fix/specs/observation/spec.md
+++ b/docs/openspec/changes/observation-layer-fix/specs/observation/spec.md
@@ -1,0 +1,57 @@
+# Observation Layer
+
+## MODIFIED Requirements
+
+### Requirement: text_content returns all matching elements
+
+When a CSS selector is provided, text_content() SHALL use querySelectorAll to return text from ALL matching elements joined by newlines, not just the first match. A max_elements parameter (default 50) SHALL cap the number of elements, appending a truncation warning when exceeded.
+
+#### Scenario: Multiple elements match selector
+Given a page with 5 elements matching ".card"
+When text_content is called with selector ".card" and max_elements 50
+Then the result contains text from all 5 elements joined by newlines
+
+#### Scenario: No elements match selector
+Given a page with no elements matching ".nonexistent"
+When text_content is called with selector ".nonexistent"
+Then the result is an empty string (not a crash)
+
+#### Scenario: Elements exceed max_elements cap
+Given a page with 100 elements matching "p"
+When text_content is called with selector "p" and max_elements 10
+Then the result contains text from 10 elements
+And the result ends with a truncation warning
+
+### Requirement: page_map supports selector scoping
+
+When a CSS selector is provided to page_map(), interactive elements, headings, and text_summary SHALL be scoped to the matched DOM subtree. If the selector does not match any element, an empty page map is returned.
+
+#### Scenario: Scoped page_map filters to subtree
+Given a page with interactive elements inside and outside ".sidebar"
+When page_map is called with selector ".sidebar"
+Then only interactive elements within the sidebar subtree are returned
+
+#### Scenario: Non-matching selector returns empty page_map
+Given a page with no element matching ".nonexistent"
+When page_map is called with selector ".nonexistent"
+Then an empty interactive array is returned (not a crash)
+
+## ADDED Requirements
+
+### Requirement: Batch abort_on_failure stops execution
+
+When abort_on_failure is true, execute_batch() SHALL stop on the first failed action and mark all remaining actions as skipped. The default is false (existing behavior preserved).
+
+#### Scenario: Abort on failure skips remaining actions
+Given a batch of 5 actions with abort_on_failure true
+When action 2 fails
+Then actions 3, 4, 5 are marked as skipped with error "Skipped (abort_on_failure)"
+
+### Requirement: Network capture records real CDP requests
+
+rayo_network capture mode SHALL wire CDP Fetch.requestPaused events to record real network requests into the NetworkInterceptor. Block rules SHALL use Fetch.failRequest and mock rules SHALL use Fetch.fulfillRequest.
+
+#### Scenario: Captured requests are non-empty after navigation
+Given network capture is started
+When a page navigation occurs
+Then rayo_network requests returns at least 1 captured request

--- a/docs/openspec/changes/observation-layer-fix/tasks.md
+++ b/docs/openspec/changes/observation-layer-fix/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Fix text_content() — querySelectorAll + null safety + max_elements param
+- [x] Fix scoped page_map — selector filters interactive elements to subtree
+- [x] Add batch abort_on_failure option
+- [x] Wire CDP Fetch events for network capture
+- [x] Add press_key() method and Press batch action
+- [x] Enhanced page_map text_summary extraction
+- [x] Update tool schemas in server.rs
+- [x] All tests pass (cargo test --workspace)
+- [x] No new clippy warnings


### PR DESCRIPTION
## Summary

- **text_content() querySelectorAll** — returns all matching elements joined by `\n` instead of first match only. Null-safe (empty string on 0 matches). New `max_elements` param (default 50) with truncation warning.
- **Scoped page_map** — `selector` param now filters interactive elements, headings, and text_summary to the matched DOM subtree. Enhanced text_summary extraction (scopes to main/article, filters invisible elements, 600 char limit).
- **Batch abort_on_failure** — new boolean param that stops batch execution on first failure and marks remaining actions as skipped.
- **Network capture via CDP Fetch** — wires `Fetch.enable()` + `Fetch.requestPaused` into `RayoPage`. Requests recorded via real CDP events. Block/mock rules enforced at the CDP level.
- **press_key()** — new method for CDP key dispatch (Enter, Tab, Escape, ArrowDown, etc.) + `Press` batch action variant.

## Bugs fixed

| Bug | Before | After |
|-----|--------|-------|
| text mode crashes on non-matching selector | `TypeError: null.textContent` | Returns empty string |
| text mode returns first match only | `querySelector` | `querySelectorAll` + join |
| page_map ignores selector param | Silently returns full page | Scopes to subtree |
| Network capture always returns 0 | No CDP event wiring | Real Fetch event handler |
| Batch runs all actions after failure | No way to stop | `abort_on_failure: true` |

## OpenSpec

Change: `observation-layer-fix` — validated with `openspec validate observation-layer-fix`

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace` — no new warnings
- [x] `cargo check --workspace` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)