### PR TITLE
feat: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: rust
+          package-name: rayo-mcp


### PR DESCRIPTION
## Summary

- Adds `release-please` GitHub Action for fully automated release flow
- No more manual `git tag` + `git push --tags`

### How it works
1. Merge PRs to main with conventional commits (`feat:`, `fix:`, etc.)
2. release-please auto-creates a "Release PR" (bumps `Cargo.toml` version, generates CHANGELOG)
3. Merge the Release PR
4. release-please creates a git tag → triggers cargo-dist → builds platform binaries → GitHub Release
5. Users' rayo instances auto-update on next startup

## Test plan

- [x] Workflow file validates (YAML syntax, correct action version)
- [ ] Merge this PR → release-please creates first Release PR on next `feat:` or `fix:` commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)