### PR TITLE
fix: extract text for role="button/link/tab" elements in page_map

### DIFF
--- a/crates/rayo-core/src/page_map.rs
+++ b/crates/rayo-core/src/page_map.rs
@@ -103,9 +103,15 @@ pub const EXTRACT_PAGE_MAP_JS: &str = r#"
             item.label = el.placeholder;
         }
 
-        // Text content (for buttons, links)
+        // Role (extracted early so text extraction can check it)
+        const role = el.getAttribute('role');
+        if (role) item.role = role;
+
+        // Text content (for buttons, links, and ARIA role equivalents)
         const text = el.textContent?.trim();
-        if (text && text.length < 100 && (el.tagName === 'BUTTON' || el.tagName === 'A')) {
+        const isTextElement = el.tagName === 'BUTTON' || el.tagName === 'A'
+            || role === 'button' || role === 'link' || role === 'tab';
+        if (text && text.length < 100 && isTextElement) {
             item.text = text;
         }
 
@@ -127,10 +133,6 @@ pub const EXTRACT_PAGE_MAP_JS: &str = r#"
                 item.options = Array.from(group).map(r => r.value);
             }
         }
-
-        // Role
-        const role = el.getAttribute('role');
-        if (role) item.role = role;
 
         // Href (links) — truncate long URLs
         if (el.href) item.href = el.href.length > 120 ? el.href.slice(0, 120) : el.href;


### PR DESCRIPTION
## Summary

- **page_map** selected elements with `role="button"`, `role="link"`, and `role="tab"` via the query selector, but only extracted visible text content for native `<button>` and `<a>` tags
- This caused elements like `<div role="button">Get started</div>` to appear as `{"id":1,"tag":"div","role":"button"}` with **no text label**, making them unidentifiable for AI agents
- Moves role extraction earlier in the JS pipeline so text extraction can check ARIA roles alongside tag names

## Context

Found during live integration testing of [company.inc](https://company.inc). The landing page has two CTA buttons rendered as `<div role="button">`:
- "Get started" (top nav)
- "Hire your first AI worker free" (hero)

Both appeared in page_map as unlabeled `div[role="button"]` elements. Clicking by ID failed with "Node is either not visible or not an HTMLElement", while clicking by CSS selector `div[role='button']` worked.

## Additional findings from the testing session

These are separate from this PR but worth tracking:

1. **Cookie import fails silently from Chrome** — `rayo_cookie import` with `browser: "chrome"` returns "Failed to set any cookies" with zero diagnostic info. Compare to Arc which helpfully shows the path tried and available profiles.

2. **Batch actions with stale element refs** — `rayo_batch` with sequential `[click, type, click]` fails on the `type` action because the preceding click may re-render the DOM, invalidating page_map IDs. The selector cache (already built in `selector_cache.rs`) should be wired into `resolve_selector()` per TODOS.md P1.

3. **DNS resolution for `.inc` TLD** — `rayo_navigate goto` to `https://company.inc` returns `net::ERR_NAME_NOT_RESOLVED` while Chrome resolves it fine. Likely a headless Chromium DNS config issue.

## Test plan

- [x] `cargo test --lib` passes (9/9)
- [ ] Manual verification: page_map should now include `text` field for `div[role="button"]` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)