### PR TITLE
feat: add dblclick action to interact and batch tools

### DIFF
--- a/crates/rayo-core/src/batch.rs
+++ b/crates/rayo-core/src/batch.rs
@@ -15,6 +15,11 @@ pub enum BatchAction {
         #[serde(flatten)]
         target: ActionTarget,
     },
+    /// Double-click an element by page map ID or selector.
+    Dblclick {
+        #[serde(flatten)]
+        target: ActionTarget,
+    },
     /// Type text into an input.
     Type {
         #[serde(flatten)]

--- a/crates/rayo-core/src/browser.rs
+++ b/crates/rayo-core/src/browser.rs
@@ -957,6 +957,55 @@ impl RayoPage {
         Ok(())
     }
 
+    /// Double-click an element by selector or page map ID.
+    /// Dispatches a real dblclick MouseEvent on the element.
+    pub async fn dblclick(
+        &self,
+        selector: Option<&str>,
+        id: Option<usize>,
+    ) -> Result<(), RayoError> {
+        self.dblclick_raw(selector, id).await?;
+        self.invalidate_after_mutation().await;
+        Ok(())
+    }
+
+    /// Internal dblclick without cache invalidation — used by batch executor
+    /// to defer all invalidation to a single pass at the end.
+    async fn dblclick_raw(
+        &self,
+        selector: Option<&str>,
+        id: Option<usize>,
+    ) -> Result<(), RayoError> {
+        let sel = self.resolve_selector(selector, id).await?;
+        let _span = self.profiler.start_span(
+            format!("dblclick({})", truncate(&sel, 40)),
+            SpanCategory::DomMutate,
+        );
+        let element =
+            self.page
+                .find_element(&sel)
+                .await
+                .map_err(|e| RayoError::ElementNotFound {
+                    selector: format!("{sel}: {e}"),
+                })?;
+        // Scroll into view first, then dispatch dblclick via JS.
+        // chromiumoxide Element doesn't expose dblclick(), so we use
+        // scroll_into_view + JS dispatchEvent for a real dblclick.
+        element
+            .scroll_into_view()
+            .await
+            .map_err(|e| RayoError::Cdp(format!("scroll_into_view failed: {e}")))?;
+        let js = format!(
+            r#"document.querySelector({}).dispatchEvent(new MouseEvent('dblclick', {{bubbles: true, cancelable: true, view: window}}))"#,
+            serde_json::to_string(&sel).unwrap()
+        );
+        self.page
+            .evaluate(js)
+            .await
+            .map_err(|e| RayoError::Cdp(format!("dblclick failed: {e}")))?;
+        Ok(())
+    }
+
     /// Hover over an element by selector or page map ID.
     /// Uses CDP Input.dispatchMouseEvent via chromiumoxide for real mouse events.
     /// Useful for triggering dropdown menus and tooltips.
@@ -1166,6 +1215,10 @@ impl RayoPage {
                 BatchAction::Click { target } => {
                     let (sel, id) = target_to_selector_id(target);
                     self.click_raw(sel, id).await.map(|_| None)
+                }
+                BatchAction::Dblclick { target } => {
+                    let (sel, id) = target_to_selector_id(target);
+                    self.dblclick_raw(sel, id).await.map(|_| None)
                 }
                 BatchAction::Type { target, value } => {
                     let (sel, id) = target_to_selector_id(target);
@@ -2218,6 +2271,7 @@ fn target_to_selector_id(target: &ActionTarget) -> (Option<&str>, Option<usize>)
 fn action_name(action: &BatchAction) -> &'static str {
     match action {
         BatchAction::Click { .. } => "click",
+        BatchAction::Dblclick { .. } => "dblclick",
         BatchAction::Type { .. } => "type",
         BatchAction::Select { .. } => "select",
         BatchAction::Press { .. } => "press",

--- a/crates/rayo-mcp/src/server.rs
+++ b/crates/rayo-mcp/src/server.rs
@@ -341,11 +341,11 @@ impl RayoServer {
             ),
             Tool::new(
                 "rayo_interact",
-                "Interact with an element. Use id from page_map or CSS selector. Actions: click, hover (mouse move without click — triggers dropdowns/tooltips), type (requires value), press (requires value — key name like \"Enter\", \"Tab\", \"Escape\", \"ArrowDown\"), select (requires value), scroll. Optional tab_id.",
+                "Interact with an element. Use id from page_map or CSS selector. Actions: click, dblclick (double-click — triggers onDoubleClick handlers), hover (mouse move without click — triggers dropdowns/tooltips), type (requires value), press (requires value — key name like \"Enter\", \"Tab\", \"Escape\", \"ArrowDown\"), select (requires value), scroll. Optional tab_id.",
                 json_schema(json!({
                     "type": "object",
                     "properties": {
-                        "action": { "type": "string", "enum": ["click", "hover", "type", "press", "select", "scroll"] },
+                        "action": { "type": "string", "enum": ["click", "dblclick", "hover", "type", "press", "select", "scroll"] },
                         "id": { "type": "integer", "description": "Element ID from page_map" },
                         "selector": { "type": "string", "description": "CSS selector (alternative to id)" },
                         "value": { "type": "string", "description": "Text to type or option to select" },
@@ -365,7 +365,7 @@ impl RayoServer {
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "action": { "type": "string", "enum": ["click", "hover", "type", "press", "select", "goto", "screenshot", "wait_for", "scroll"] },
+                                    "action": { "type": "string", "enum": ["click", "dblclick", "hover", "type", "press", "select", "goto", "screenshot", "wait_for", "scroll"] },
                                     "id": { "type": "integer" },
                                     "selector": { "type": "string" },
                                     "value": { "type": "string" },

--- a/crates/rayo-mcp/src/tools/mod.rs
+++ b/crates/rayo-mcp/src/tools/mod.rs
@@ -293,6 +293,10 @@ pub async fn handle_interact(
             page.click(selector, id).await.map_err(internal_err)?;
             "Clicked".to_string()
         }
+        "dblclick" => {
+            page.dblclick(selector, id).await.map_err(internal_err)?;
+            "Double-clicked".to_string()
+        }
         "hover" => {
             page.hover(selector, id).await.map_err(internal_err)?;
             "Hovered".to_string()

--- a/crates/rayo-ui/src/runner.rs
+++ b/crates/rayo-ui/src/runner.rs
@@ -668,6 +668,7 @@ fn to_batch_action(a: &BatchStepAction, base_url: Option<&str>) -> Option<BatchA
 
     match a.action.as_str() {
         "click" => Some(BatchAction::Click { target }),
+        "dblclick" => Some(BatchAction::Dblclick { target }),
         "type" => Some(BatchAction::Type {
             target,
             value: a.value.clone().unwrap_or_default(),


### PR DESCRIPTION
## Summary
- Adds `dblclick` as a new action for `rayo_interact` and `rayo_batch` tools
- Uses `scroll_into_view()` + JS `dispatchEvent(new MouseEvent('dblclick'))` since chromiumoxide Element doesn't expose a native dblclick method
- Needed because some web apps use `onDoubleClick` handlers that can't be triggered by two sequential single clicks

## Changes
- **`rayo-core/src/batch.rs`** — Added `Dblclick` variant to `BatchAction` enum
- **`rayo-core/src/browser.rs`** — Added `dblclick()` / `dblclick_raw()` methods mirroring the click pattern, plus batch executor and `action_name` mapping
- **`rayo-mcp/src/server.rs`** — Added `dblclick` to both `rayo_interact` and `rayo_batch` JSON schema enums, updated tool description
- **`rayo-mcp/src/tools/mod.rs`** — Added `dblclick` action handler in the interact tool match
- **`rayo-ui/src/runner.rs`** — Added `dblclick` mapping in the YAML test runner

## Test plan
- [x] `cargo check` passes cleanly
- [x] `cargo test --lib` — all 27 tests pass
- [ ] Manual test: use `rayo_interact` with `{"action": "dblclick", "selector": "..."}` on an element with a dblclick handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)